### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ go version
 If your distribution comes with an older version of golang or the required version is not included in the repository, download and install golang manually. 
 
 ```console
-sudo curl -O https://storage.googleapis.com/golang/go1.9.1.linux-amd64.tar.gz
-sudo tar -xvf go1.9.1.linux-amd64.tar.gz
+sudo curl -O https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz
+sudo tar -xvf go1.13.8.linux-amd64.tar.gz
 sudo mv go /usr/local
 ```
 


### PR DESCRIPTION
Changing the source Go library from 1.9 to 1.13. This currently errors out with the older libarary.

https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz
sudo tar -xvf go1.13.8.linux-amd64.tar.gz